### PR TITLE
require "date" before opening class Date

### DIFF
--- a/lib/bson/date.rb
+++ b/lib/bson/date.rb
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require "date"
+
 module BSON
 
   # Injects behaviour for encoding date values to raw bytes as specified by


### PR DESCRIPTION
Before the changes:

```
$ ruby -Ilib -rbson -e "puts 42"
/home/dmurik/world/bson-ruby/lib/bson/date.rb:50:in `<module:BSON>': uninitialized constant Date (NameError)
    from /home/dmurik/world/bson-ruby/lib/bson/date.rb:15:in `<top (required)>'
    from /home/dmurik/.rvm/rubies/ruby-2.2.0/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require'
    from /home/dmurik/.rvm/rubies/ruby-2.2.0/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require'
    from /home/dmurik/world/bson-ruby/lib/bson.rb:55:in `<top (required)>'
    from /home/dmurik/.rvm/rubies/ruby-2.2.0/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require'
    from /home/dmurik/.rvm/rubies/ruby-2.2.0/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require'
```

After the change:

```
$ ruby -Ilib -rbson -e "puts 42"
42
```

P.S. I believe this is not caught in `rake spec` because something requires `date` before bson is loaded. But I haven't investigated it.
